### PR TITLE
feat: modify HTML_CLASS_REGEX to match class surrounded by single quotation.

### DIFF
--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Leaving 'd' out to avoid generating the word 'ad'
-var defaultAlphabet = 'abcefghijklmnopqrstuvwxyz0123456789_-';
+var defaultAlphabet = 'abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-';
 
 var IdGenerator = function IdGenerator(alphabet) {
   var options = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ var IdGenerator = require('./idGenerator');
 
 var CLASS_NAME_REGEX = /\/\*[\s\S]*?\*\/|(\.[a-z_-][\w-]*)(?=[^{}]*{)/g; // https://stackoverflow.com/a/48962872/5133130
 
-var HTML_CLASS_REGEX = /class="([\w-\s]*)"/g;
+var HTML_CLASS_REGEX = /class=["|']{1}([\w-\s]*)["|']{1}/g;
 /**
  * Provides methods to replaces CSS class names
  * @constructor

--- a/src/idGenerator.js
+++ b/src/idGenerator.js
@@ -1,5 +1,5 @@
 // Leaving 'd' out to avoid generating the word 'ad'
-const defaultAlphabet = 'abcefghijklmnopqrstuvwxyz0123456789_-';
+const defaultAlphabet = 'abcefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-';
 
 var IdGenerator = function(alphabet) {
   var options = {

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const replaceStream = require('replacestream');
 const IdGenerator = require('./idGenerator');
 
 const CLASS_NAME_REGEX = /\/\*[\s\S]*?\*\/|(\.[a-z_-][\w-]*)(?=[^{}]*{)/g; // https://stackoverflow.com/a/48962872/5133130
-const HTML_CLASS_REGEX = /class="([\w-\s]*)"/g;
+const HTML_CLASS_REGEX = /class=["|']{1}([\w-\s]*)["|']{1}/g;
 
 /**
  * Provides methods to replaces CSS class names


### PR DESCRIPTION
A classname can be surrounded by double quotation and single quotation. But now our HTML_CLASS_REGEX only match the classname surrounded by double quotation.

